### PR TITLE
Updated blank Windows Store app with TypeScript template 

### DIFF
--- a/TemplatePack/ProjectTemplates/Windows Store/TypeScript Blank/WSaTypeScript.jsproj
+++ b/TemplatePack/ProjectTemplates/Windows Store/TypeScript Blank/WSaTypeScript.jsproj
@@ -89,6 +89,5 @@
     <TypeScriptSourceMap>false</TypeScriptSourceMap>
     <TypeScriptModuleKind>AMD</TypeScriptModuleKind>
   </PropertyGroup>
-  <!--<Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v12.0\TypeScript\Microsoft.TypeScript.targets" /> -->
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.VisualStudio.$(WMSJSProject).targets" />
+   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.VisualStudio.$(WMSJSProject).targets" />
 </Project>


### PR DESCRIPTION
Updated the template. It uses the .target files that came with TypeScript now. 
