### PR TITLE
addressed testing of psbuild module installation and import

### DIFF
--- a/build-debug.ps1
+++ b/build-debug.ps1
@@ -68,11 +68,17 @@ function EnsurePsbuildInstalled(){
     [cmdletbinding()]
     param()
     process{
-        # TODO: This doesn't seemm reliable, revisit this later
+        # get-module -listavailable 'psbuild' will list installed modules on the host
+        # get-module 'psbuild' will list modules imported into the current session
 
-        if(!(Get-Module 'psbuild')){
+        if(!(Get-Module -listAvailable 'psbuild')){
             $msg = ('psbuild is required for this script, but it does not look to be installed. Get psbuild from here: https://github.com/ligershark/psbuild')
             throw $msg
+        }
+
+        if(!(Get-Module 'psbuild')){
+            # add psbuild to the currently loaded session modules
+            import-module psbuild -Global;
         }
     }
 }


### PR DESCRIPTION
Ok, I took a look and I think this is what you're after.  Get-Module 'psbuild' checks for a module named PSBUILD that is already loaded in the current session.  This is a valid check, you need to do this because I don't see you importing the module explicitly anywhere.  

Get-Module -listavailable 'psbuild' checks for modules named PSBUILD that are INSTALLED and ready for import.

I modified the code using the convention I'm familiar with.  Discuss.
