### PR TITLE
isolated first found instance of imagecompressor.job.exe to simplify ret...

### DIFF
--- a/build-main.ps1
+++ b/build-main.ps1
@@ -112,17 +112,11 @@ function GetImageOptimizer(){
             &(GetNuGet) $cmdArgs | Out-Null
         }
 
-        $imgOptimizer = (Get-ChildItem -Path $toolsDir -Include 'ImageCompressor.Job.exe' -Recurse)
-        if(!$imgOptimizer){ throw 'Image optimizer not found' }       
+        $imgOptimizer = Get-ChildItem -Path $toolsDir -Include 'ImageCompressor.Job.exe' -Recurse | select -first 1
+        # imgOptimizer is now a single fileinfo reference, or $null
 
-        # return the path to it
-        if($imgOptimizer -is [Array]){
-            # incase somehow more than one ImageCompressor.Job.exe shows up in that folder
-            $imgOptimizer[0]
-        }
-        else{
-            $imgOptimizer
-        }
+        if(!$imgOptimizer){ throw 'Image optimizer not found' }
+        $imgOptimizer
     }
 }
 


### PR DESCRIPTION
...urn value checks.

basically, you had it in your tweet.  the convention of select -first 1 is used often to isolate the first found "thing" and guarantee a scalar result.

alternatively, you can force the results to a list by surrounding them with @().  e.g.,:

```
$imgOptimizer = @(Get-ChildItem -Path $toolsDir -Include 'ImageCompressor.Job.exe' -Recurse)
#imgOptimizer is now a list, which may be empty
```
