### PR TITLE
Typescript AngularJS templates updated to be Typescript 1.0 and Angular 1.3 compatible...

### DIFF
--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Controller using $scope/controller.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Controller using $scope/controller.ts
@@ -10,24 +10,14 @@ interface I$safeitemname$Scope extends ng.IScope {
     changeGreeting: () => void;
 }
 
-interface I$safeitemname$ {
-    controllerId: string;
-}
-
-class $safeitemname$ implements I$safeitemname$ {
-    static controllerId: string = "$safeitemname$";
-    
-    constructor(private $scope: I$safeitemname$Scope, private $http: ng.IHttpService, private $resource: ng.resource.IResourceService) {
-        $scope.greeting = "Hello";
-        $scope.changeGreeting = () => this.changeGreeting();
-    }
-
-    private changeGreeting() {
-        this.$scope.greeting = "Bye";
-    }
+function $safeitemname$($scope: I$safeitemname$Scope, $http: ng.IHttpService, $resource: ng.resource.IResourceService) {
+    $scope.greeting = "Hello";
+    $scope.changeGreeting = (): void => {
+        $scope.greeting = "Bye";
+    };
 }
 
 // Update the app1 variable name to be that of your module variable
-app1.controller($safeitemname$.controllerId, ['$scope', '$http', '$resource', ($scope, $http, $resource) =>
-    new $safeitemname$($scope, $http, $resource)
+app1.controller("$safeitemname$", ['$scope', '$http', '$resource',
+    $safeitemname$
 ]);

--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Controller/controller.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Controller/controller.ts
@@ -5,29 +5,22 @@
 /// <reference path='/Scripts/typings/angularjs/angular.d.ts'/>
 /// <reference path='/Scripts/typings/angularjs/angular-resource.d.ts'/>
 
-interface I$safeitemname$Scope extends ng.IScope {
-    vm: $safeitemname$;
-}
-
 interface I$safeitemname$ {
     greeting: string;
-    controllerId: string;
     changeGreeting: () => void;
 }
 
-class $safeitemname$ implements I$safeitemname$ {
-    static controllerId: string = "$safeitemname$";
-    greeting = "Hello";
-    
-    constructor(private $scope: I$safeitemname$Scope, private $http: ng.IHttpService, private $resource: ng.resource.IResourceService) {
-    }
+function $safeitemname$($scope: ng.IScope, $http: ng.IHttpService, $resource: ng.resource.IResourceService){
+    var vm: I$safeitemname$ = this;
+    vm.greeting = "Hello";
 
-    changeGreeting() {
-        this.greeting = "Bye";
+    vm.changeGreeting=(): void =>{
+        vm.greeting = "Bye";
     }
 }
 
+
 // Update the app1 variable name to be that of your module variable
-app1.controller($safeitemname$.controllerId, ['$scope', '$http', '$resource', ($scope, $http, $resource) =>
-    new $safeitemname$($scope, $http, $resource)
+app1.controller("$safeitemname$", ['$scope', '$http', '$resource', 
+    $safeitemname$
 ]);

--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Directive/directive.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Directive/directive.ts
@@ -6,7 +6,6 @@
 /// <reference path='/Scripts/typings/angularjs/angular-resource.d.ts'/>
 
 interface I$safeitemname$ extends ng.IDirective {
-    directiveId: string;
 }
 
 interface I$safeitemname$Scope extends ng.IScope {

--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Factory/factory.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Factory/factory.ts
@@ -7,7 +7,6 @@
 
 interface I$safeitemname$ {
     greeting: string;
-    serviceId: string;
     changeGreeting: () => void;
 }
 


### PR DESCRIPTION
*  Controller templates:  changed to be implemented as functions rather
than classes; removed controllerId variable
*  Factory Template:  serviceId variable was removed from the interface
definition, since it is a static member of the class
*  Directive Template:  directiveId variable was removed from the
interface definition, since it is a static member of the class

This is my first ever PR.  Feel free to chastise me if I did anything wrong.  A couple of quick notes:

1)  Since I don't often work with directories or factories, I don't know if Angular 1.3 requires that those templates be converted to functions as well.  If so, it's a quick change, but feedback from Mads or JohnPapa would be helpful..
2)  My version of VS won't open the template project.  As a result, I wasn't able to compile and test it.  It went over the files three times, and I don't see any typos or errors.