### PR TITLE
Updated Caliburn.Micro Template

### DIFF
--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/AppBootstrapper.cs
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/AppBootstrapper.cs
@@ -13,7 +13,7 @@ namespace $safeprojectname$
 
 		protected override void OnStartup(object sender, StartupEventArgs e)
 		{
-			DisplayRootViewFor<MainViewModel>();
+			DisplayRootViewFor<ShellViewModel>();
 		}
 	}
 }

--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Caliburn.Micro WPF Application.csproj
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Caliburn.Micro WPF Application.csproj
@@ -70,9 +70,9 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="ViewModels\MainViewModel.cs" />
-    <Compile Include="Views\MainView.xaml.cs">
-      <DependentUpon>MainView.xaml</DependentUpon>
+    <Compile Include="ViewModels\ShellViewModel.cs" />
+    <Compile Include="Views\ShellView.xaml.cs">
+      <DependentUpon>ShellView.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -106,7 +106,7 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
-    <Page Include="Views\MainView.xaml">
+    <Page Include="Views\ShellView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Caliburn.Micro WPF Application.csproj
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Caliburn.Micro WPF Application.csproj
@@ -39,15 +39,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Caliburn.Micro">
-      <HintPath>..\packages\Caliburn.Micro.Core.2.0.0\lib\net45\Caliburn.Micro.dll</HintPath>
+      <HintPath>..\packages\Caliburn.Micro.Core.2.0.2\lib\net45\Caliburn.Micro.dll</HintPath>
     </Reference>
     <Reference Include="Caliburn.Micro.Platform">
-      <HintPath>..\packages\Caliburn.Micro.2.0.0\lib\net45\Caliburn.Micro.Platform.dll</HintPath>
+      <HintPath>..\packages\Caliburn.Micro.2.0.2\lib\net45\Caliburn.Micro.Platform.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Caliburn.Micro.2.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <HintPath>..\packages\Caliburn.Micro.2.0.2\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Properties/AssemblyInfo.cs
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Properties/AssemblyInfo.cs
@@ -7,11 +7,11 @@ using System.Windows;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("CaliburnMicro.CSharp.Empty")]
+[assembly: AssemblyTitle("$safeprojectname$")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CaliburnMicro.CSharp.Empty")]
+[assembly: AssemblyProduct("$safeprojectname$")]
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/ViewModels/ShellViewModel.cs
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/ViewModels/ShellViewModel.cs
@@ -2,11 +2,11 @@
 
 namespace $safeprojectname$.ViewModels
 {
-	public class MainViewModel : PropertyChangedBase, IHaveDisplayName
+	public class ShellViewModel : PropertyChangedBase, IHaveDisplayName
     {
-        public MainViewModel()
+        public ShellViewModel()
         {
-            DisplayName = "Main Window";
+            DisplayName = "Shell Window";
         }
 
         /// <summary>

--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Views/ShellView.xaml
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Views/ShellView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="$safeprojectname$.Views.MainView"
+﻿<UserControl x:Class="$safeprojectname$.Views.ShellView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Views/ShellView.xaml.cs
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/Views/ShellView.xaml.cs
@@ -3,11 +3,11 @@
 namespace $safeprojectname$.Views
 {
 	/// <summary>
-	/// Interaction logic for Main.xaml
+	/// Interaction logic for Shell.xaml
 	/// </summary>
-	public partial class MainView : UserControl
+	public partial class ShellView : UserControl
 	{
-		public MainView()
+		public ShellView()
 		{
 			InitializeComponent();
 		}

--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/_Definitions/CSharp.vstemplate
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/_Definitions/CSharp.vstemplate
@@ -28,11 +28,11 @@
 				<ProjectItem ReplaceParameters="true" TargetFileName="Settings.Designer.cs">Settings.Designer.cs</ProjectItem>
 			</Folder>
 			<Folder Name="ViewModels" TargetFolderName="ViewModels">
-				<ProjectItem ReplaceParameters="true" TargetFileName="MainViewModel.cs">MainViewModel.cs</ProjectItem>
+				<ProjectItem ReplaceParameters="true" TargetFileName="ShellViewModel.cs">ShellViewModel.cs</ProjectItem>
 			</Folder>
 			<Folder Name="Views" TargetFolderName="Views">
-				<ProjectItem ReplaceParameters="true" TargetFileName="MainView.xaml">MainView.xaml</ProjectItem>
-				<ProjectItem ReplaceParameters="true" TargetFileName="MainView.xaml.cs">MainView.xaml.cs</ProjectItem>
+				<ProjectItem ReplaceParameters="true" TargetFileName="ShellView.xaml">ShellView.xaml</ProjectItem>
+				<ProjectItem ReplaceParameters="true" TargetFileName="ShellView.xaml.cs">ShellView.xaml.cs</ProjectItem>
 			</Folder>
 		</Project>
 	</TemplateContent>

--- a/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/packages.config
+++ b/TemplatePack/ProjectTemplates/Windows/Caliburn.Micro WPF Application/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Caliburn.Micro" version="2.0.0" targetFramework="net45" />
-  <package id="Caliburn.Micro.Core" version="2.0.0" targetFramework="net45" />
+  <package id="Caliburn.Micro" version="2.0.2" targetFramework="net45" />
+  <package id="Caliburn.Micro.Core" version="2.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I've been using this template and I'd like to provide a couple of little fixes and updates that bugged me when I was trying to make use of it.

- Changed all references of "Main" to "Shell" to better match the Caliburn.Micro documentation.
- Placed the project name in the AssemblyInfo.cs file, as is standard for most project templates.
- Upgraded the Caliburn.Micro nuget package to the latest release version.

Let me know if anything needs changing.