### PR TITLE
Updated README to include VS 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ##The ultimate web developer template pack
 
-A collection of Item Templates for Visual Studio 2012/2013 
+A collection of Item Templates for Visual Studio 2012/2013/2015 
 that makes any web developer's life much easier.
 
 ![The result of a search for "angular" in the "Add new item" dialog](screenshot.png)  
@@ -17,13 +17,13 @@ The result of a search for "angular" in the "Add new item" dialog
 
 1. Fork the project
 2. Clone it to your computer
-3. Install the [Visual Studio 2012 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=30668) or [Visual Studio 2013 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=40758).
+3. Install the [Visual Studio 2012 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=30668), [Visual Studio 2013 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=40758), or [Visual Studio 2015 SDK RC](http://go.microsoft.com/?linkid=9877247).
 4. Open the solution in Visual Studio
 5. Watch [this video tutorial](http://youtu.be/h4VaORKgrOw)
 6. After adding your templates, send us a pull request
  * Only high quality templates with broad appeal will be accepted
 
-SideWaffle templates can be installed in both Visual Studio 2012 and 2013, regardless of the version you use for creating new templates.
+SideWaffle templates can be installed in Visual Studio 2012, 2013 and 2015, regardless of the version you use for creating new templates.
 
 Learn more about on MSDN about [customizing item templates](http://msdn.microsoft.com/en-us/library/ms247113.aspx)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ that makes any web developer's life much easier.
 
 1. Fork the project
 2. Clone it to your computer
-3. Install the [Visual Studio 2012 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=30668), [Visual Studio 2013 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=40758), or [Visual Studio 2015 SDK RC](http://go.microsoft.com/?linkid=9877247).
+3. Install the [Visual Studio 2012 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=30668), 
+[Visual Studio 2013 SDK](http://www.microsoft.com/en-us/download/details.aspx?id=40758), or 
+[Visual Studio 2015 SDK RC](http://go.microsoft.com/?linkid=9877247).
 4. Open the solution in Visual Studio
 5. Watch [this video tutorial](http://youtu.be/h4VaORKgrOw)
 6. After adding your templates, send us a pull request

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 A collection of Item Templates for Visual Studio 2012/2013/2015 
 that makes any web developer's life much easier.
 
-![The result of a search for "angular" in the "Add new item" dialog](screenshot.png)The result of a search for "angular" in the "Add new item" dialog
+![The result of a search for "angular" in the "Add new item" dialog](screenshot.png)
+The result of a search for "angular" in the "Add new item" dialog
 
 ##Add new templates##
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of Item Templates for Visual Studio 2012/2013/2015
 that makes any web developer's life much easier.
 
 ![The result of a search for "angular" in the "Add new item" dialog](screenshot.png)
-The result of a search for "angular" in the "Add new item" dialog
+The result of a search for "angular" in the "Add new item" dialog
 
 ##Add new templates##
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 A collection of Item Templates for Visual Studio 2012/2013/2015 
 that makes any web developer's life much easier.
 
-![The result of a search for "angular" in the "Add new item" dialog](screenshot.png)  
-The result of a search for "angular" in the "Add new item" dialog
+![The result of a search for "angular" in the "Add new item" dialog](screenshot.png)The result of a search for "angular" in the "Add new item" dialog
 
 ##Add new templates##
 


### PR DESCRIPTION
This PR also removes an encoding control tag that was in the README. This control tag did not show up in the Web Essentials Markdown editor. It only showed up when the README is generated on GitHub.