### PR TITLE
Fixed usability issues with Dynamic Templates settings dialog

### DIFF
--- a/TemplatePack/SettingsForm.Designer.cs
+++ b/TemplatePack/SettingsForm.Designer.cs
@@ -155,6 +155,7 @@
             // 
             // sourceUrlTextBox
             // 
+            this.sourceUrlTextBox.Enabled = false;
             this.sourceUrlTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.sourceUrlTextBox.Location = new System.Drawing.Point(88, 252);
             this.sourceUrlTextBox.Name = "sourceUrlTextBox";
@@ -164,6 +165,7 @@
             // 
             // sourceNameTextBox
             // 
+            this.sourceNameTextBox.Enabled = false;
             this.sourceNameTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.sourceNameTextBox.Location = new System.Drawing.Point(88, 224);
             this.sourceNameTextBox.Name = "sourceNameTextBox";

--- a/TemplatePack/SettingsForm.cs
+++ b/TemplatePack/SettingsForm.cs
@@ -111,6 +111,8 @@ namespace TemplatePack
                 sourceBranchTextBox.Enabled = false;
                 sourceBranchTextBox.Text = "origin/master";
             }
+            // Enable the newly created template (default setting)
+            CurrentItemSelected.Checked = true;
 
             applyBtn.Visible = true;
         }

--- a/TemplatePack/SettingsForm.cs
+++ b/TemplatePack/SettingsForm.cs
@@ -58,6 +58,12 @@ namespace TemplatePack
                 sourceNameTextBox.Text = CurrentItemSelected.SubItems[1].Text;
                 sourceUrlTextBox.Text = CurrentItemSelected.SubItems[2].Text;
 
+                if (sourceNameTextBox.Enabled == false && sourceUrlTextBox.Enabled == false)
+                {
+                    sourceNameTextBox.Enabled = true;
+                    sourceUrlTextBox.Enabled = true;
+                }
+
                 if (CurrentItemSelected.SubItems[3].Text != "")
                 {
                     sourceBranchTextBox.Enabled = true;
@@ -92,6 +98,12 @@ namespace TemplatePack
 
         private void newSourceBtn_Click(object sender, EventArgs e)
         {
+            if (sourceNameTextBox.Enabled == false && sourceUrlTextBox.Enabled == false)
+            {
+                sourceNameTextBox.Enabled = true;
+                sourceUrlTextBox.Enabled = true;
+            }
+
             // Add new row to the ListView
             ListViewItem row = new ListViewItem();
             row.SubItems.Add(String.Empty);


### PR DESCRIPTION
- Disabled the Name and URL textboxes by default
- Set Name and URL textboxes to be reenabled when either the New Source button is clicked or when a source is selected and the Edit button is clicked
- When adding a new source it is not enabled by default

This fixes all the problems mentioned in #311.