### PR TITLE
Add missing delimiter in _preprocess.xml files

### DIFF
--- a/Project Templates/_SampleProjRef/_preprocess.xml
+++ b/Project Templates/_SampleProjRef/_preprocess.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Preprocess>
   <TemplateInfo Path="CSharp\Web\SideWaffle\Custom\Subcategory"/>
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj*.jpg;*.png;*.ico;_preprocess.xml">
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;_preprocess.xml">
     <add key="_SampleProjRef" value="$safeprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/Project Templates/_SampleProjRef/_preprocess.xml
+++ b/Project Templates/_SampleProjRef/_preprocess.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Preprocess>
   <TemplateInfo Path="CSharp\Web\SideWaffle\Custom\Subcategory"/>
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;_preprocess.xml">
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.jpg;*.png;*.ico;_preprocess.xml">
     <add key="_SampleProjRef" value="$safeprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/TemplatePack/ItemTemplates/Extensibility/SideWaffle/SideWaffle-PreprocessXml/_preprocess.xml
+++ b/TemplatePack/ItemTemplates/Extensibility/SideWaffle/SideWaffle-PreprocessXml/_preprocess.xml
@@ -6,7 +6,7 @@
   
   <TemplateInfo Path="CSharp\Web\Custom\Subcategory"/>
   -->
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;_preprocess.xml">
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.jpg;*.png;*.ico;_preprocess.xml">
     <add key="My.Namespace" value="$safeprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/TemplatePack/ItemTemplates/Extensibility/SideWaffle/SideWaffle-PreprocessXml/_preprocess.xml
+++ b/TemplatePack/ItemTemplates/Extensibility/SideWaffle/SideWaffle-PreprocessXml/_preprocess.xml
@@ -6,7 +6,7 @@
   
   <TemplateInfo Path="CSharp\Web\Custom\Subcategory"/>
   -->
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj*.jpg;*.png;*.ico;_preprocess.xml">
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;_preprocess.xml">
     <add key="My.Namespace" value="$safeprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/TemplatePack/ProjectTemplates/Extensibility/AspNetScaffolding/Basic/CustomScaffolder/_preprocess.xml
+++ b/TemplatePack/ProjectTemplates/Extensibility/AspNetScaffolding/Basic/CustomScaffolder/_preprocess.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Preprocess>
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;templateinfo.xml">
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.jpg;*.png;*.ico;templateinfo.xml">
     <add key="CustomScaffolder" value="$saferootprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/TemplatePack/ProjectTemplates/Extensibility/AspNetScaffolding/Basic/CustomScaffolder/_preprocess.xml
+++ b/TemplatePack/ProjectTemplates/Extensibility/AspNetScaffolding/Basic/CustomScaffolder/_preprocess.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Preprocess>
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj*.jpg;*.png;*.ico;templateinfo.xml">
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;templateinfo.xml">
     <add key="CustomScaffolder" value="$saferootprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/TemplatePack/ProjectTemplates/Extensibility/AspNetScaffolding/Basic/CustomScaffolderExtension/_preprocess.xml
+++ b/TemplatePack/ProjectTemplates/Extensibility/AspNetScaffolding/Basic/CustomScaffolderExtension/_preprocess.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Preprocess>
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj*.jpg;*.png;*.ico;templateinfo.xml">   
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;templateinfo.xml">   
     <add key="CustomScaffolder" value="$saferootprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/TemplatePack/ProjectTemplates/Extensibility/AspNetScaffolding/Basic/CustomScaffolderExtension/_preprocess.xml
+++ b/TemplatePack/ProjectTemplates/Extensibility/AspNetScaffolding/Basic/CustomScaffolderExtension/_preprocess.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Preprocess>
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;templateinfo.xml">   
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.jpg;*.png;*.ico;templateinfo.xml">   
     <add key="CustomScaffolder" value="$saferootprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/TemplatePack/ProjectTemplates/Web/_SampleNewWeb/_preprocess.xml
+++ b/TemplatePack/ProjectTemplates/Web/_SampleNewWeb/_preprocess.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Preprocess>
   <TemplateInfo Path="CSharp\Web\SideWaffle\Custom\Subcategory"/>
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj*.jpg;*.png;*.ico;_preprocess.xml">
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;_preprocess.xml">
     <add key="WebApplication1" value="$safeprojectname$"/>
   </Replacements>
 </Preprocess>

--- a/TemplatePack/ProjectTemplates/Web/_SampleNewWeb/_preprocess.xml
+++ b/TemplatePack/ProjectTemplates/Web/_SampleNewWeb/_preprocess.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Preprocess>
   <TemplateInfo Path="CSharp\Web\SideWaffle\Custom\Subcategory"/>
-  <Replacements Include="*.*" Exclude="*.vstemplate;*.csproj;*.jpg;*.png;*.ico;_preprocess.xml">
+  <Replacements Include="*.*" Exclude="*.vstemplate;*.jpg;*.png;*.ico;_preprocess.xml">
     <add key="WebApplication1" value="$safeprojectname$"/>
   </Replacements>
 </Preprocess>


### PR DESCRIPTION
The semi-colon delimiter was missing in between `*.csproj` and `*.jpg` in 5 of the `_preprocess.xml` files.