### PR TITLE
Updated Angular TypeScript templates

### DIFF
--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Controller using $scope/controller.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Controller using $scope/controller.ts
@@ -2,7 +2,7 @@
 module App {
     "use strict";
 
-    interface I$safeitemname$Scope extends ng.IScope {
+    interface I$safeitemname$Scope extends angular.IScope {
         title: string;
     }
 

--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Controller/controller.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Controller/controller.ts
@@ -12,7 +12,7 @@ module App {
 
         static $inject: string[] = ["$location"];
 
-        constructor(private $location: ng.ILocationService) {
+        constructor(private $location: angular.ILocationService) {
             this.activate();
         }
 

--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Directive/directive.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Directive/directive.ts
@@ -2,17 +2,17 @@
 module App {
     "use strict";
 
-    interface I$safeitemname$ extends ng.IDirective {
+    interface I$safeitemname$ extends angular.IDirective {
     }
 
-    interface I$safeitemname$Scope extends ng.IScope {
+    interface I$safeitemname$Scope extends angular.IScope {
     }
 
-    interface I$safeitemname$Attributes extends ng.IAttributes {
+    interface I$safeitemname$Attributes extends angular.IAttributes {
     }
 
     $safeitemname$.$inject = ["$window"];
-    function $safeitemname$($window: ng.IWindowService): I$safeitemname$ {
+    function $safeitemname$($window: angular.IWindowService): I$safeitemname$ {
         // Usage:
         //     <$directiveUsage$></$directiveUsage$>
         // Creates:
@@ -22,7 +22,7 @@ module App {
             link: link
         }
 
-        function link(scope: I$safeitemname$Scope, element: ng.IAugmentedJQuery, attrs: I$safeitemname$Attributes) {
+        function link(scope: I$safeitemname$Scope, element: angular.IAugmentedJQuery, attrs: I$safeitemname$Attributes) {
 
         }
     }

--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Factory/factory.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Factory/factory.ts
@@ -8,7 +8,7 @@ module App {
 
     $safeitemname$.$inject = ["$http"];
 
-    function $safeitemname$($http: ng.IHttpService): I$safeitemname$ {
+    function $safeitemname$($http: angular.IHttpService): I$safeitemname$ {
         var service: I$safeitemname$ = {
             getData: getData
         };

--- a/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Service/service.ts
+++ b/TemplatePack/ItemTemplates/TypeScript/AngularJs/TypeScript Service/service.ts
@@ -9,7 +9,7 @@ module App {
     class $safeitemname$ implements I$safeitemname$ {
         static $inject: string[] = ["$http"];
 
-        constructor(private $http: ng.IHttpService) {
+        constructor(private $http: angular.IHttpService) {
         }
 
         getData() {

--- a/TemplatePack/TemplatePack.csproj
+++ b/TemplatePack/TemplatePack.csproj
@@ -56,6 +56,10 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <None Include="ItemTemplates\Web\TypeScript\Angular2\Component\icon.png" />
+    <Content Include="ItemTemplates\TypeScript\AngularJs\TypeScript Service\icon.png" />
+    <Content Include="ItemTemplates\TypeScript\AngularJs\TypeScript Service\_Definitions\CSharp.vstemplate" />
+    <Content Include="ItemTemplates\TypeScript\AngularJs\TypeScript Service\_Definitions\VB.vstemplate" />
+    <Content Include="ItemTemplates\TypeScript\AngularJs\TypeScript Service\_Definitions\Web.csharp.vstemplate" />
     <Content Include="ItemTemplates\Web\TypeScript\Angular2\Pipe\Definitions\CSharp.vstemplate" />
     <Content Include="ItemTemplates\Web\TypeScript\Angular2\Pipe\Definitions\VB.vstemplate" />
     <Content Include="ItemTemplates\Web\TypeScript\Angular2\Pipe\Definitions\Web.csharp.vstemplate" />
@@ -1174,6 +1178,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="ItemTemplates\Web\TypeScript\Angular2\Pipe\pipe.ts" />
+  </ItemGroup>
+  <ItemGroup>
+    <TypeScriptCompile Include="ItemTemplates\TypeScript\AngularJs\TypeScript Service\service.ts" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/release-notes.xml
+++ b/release-notes.xml
@@ -7,6 +7,7 @@
     <note type="item-template">
         Changed the AngularJs directive templates to fix a bug with the usage comments <a href="https://github.com/ligershark/side-waffle/issues/285">issue #285</a>
     </note>
+    <note type="item-template">Updated Angular TypeScript templates to reflect changes made to the Angular type definitions</note>
 	  <note type="project-template">Updated Project Template - The packages of Nancy project templates</note>
 	  <note type="project-template">Updated Project Template - The framework versions of Nancy project templates are set to 4.6.1</note>
   </Version>


### PR DESCRIPTION
DefinitelyTyped definitions for angular have changed the namespace of angular interfaces from `ng` to `angular` 