### PR TITLE
Added verification for publishing to the VSIX Gallery

### DIFF
--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -13,4 +13,8 @@ else{
     .\build-main.ps1
 }
 
-Vsix-PushArtifacts | Vsix-PublishToGallery
+Vsix-PushArtifacts
+
+if ($env:APPVEYOR_REPO_NAME -eq "ligershark/side-waffle") {
+	Vsix-PublishToGallery
+}


### PR DESCRIPTION
This fixes #354. 

Here are screenshots from before and after the fix showing that it no longer publishes to the VSIX Gallery on my fork.

**BEFORE**
![vsix_gallery_fix_before](https://cloud.githubusercontent.com/assets/2483249/13660595/2d23d754-e651-11e5-9db5-11c898734fa6.PNG)

**AFTER**

![vsix_gallery_fix_after](https://cloud.githubusercontent.com/assets/2483249/13660615/4b17d4f4-e651-11e5-8730-1712572f0f4c.PNG)


Seeing as all the work has been done on my fork I have not been able to test this on the main repo to make sure that it still pushes to the VSIX Gallery there.

