### PR TITLE
Fix broken link.  Send users to VS Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/bwirtvfcnjix07pd?svg=true)](https://ci.appveyor.com/project/sayedihashimi/side-waffle)
 [![Join the chat at https://gitter.im/ligershark/side-waffle](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ligershark/side-waffle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[SideWaffle.com](http://sidewaffle.com) - download the extension
+[SideWaffle](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.SideWaffleTemplatePack) - download the extension
 
 ## The ultimate web developer template pack
 


### PR DESCRIPTION
Send users to the VS marketplace to install SideWaffle since the SideWaffle.com website is showing a 404 error.